### PR TITLE
New: Support `/` separator(`aspect-ratio: 16 / 9`)，fix #6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.0 - 2020-05-13
+* Support `/` separator(`aspect-ratio: 16 / 9`)
+* One or more whitespace characters are supported before or after the separator.
+* Use number-precision module to fix JS calculation precision problem.
+
 # 1.0.1 - 2018-12-03
 * Fix: `npm test` error(In Node.js 10.0.0, the callback parameter is no longer optional. Not passing it will throw a TypeError at runtime. See [doc](https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback))
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A PostCSS plugin to fix an element's dimensions to an aspect ratio.
 
+There is already a standard [aspect-ratio](https://drafts.csswg.org/css-sizing-4/#aspect-ratio) in the CSS specification, and Chrome has [experimental support](https://bugs.chromium.org/p/chromium/issues/detail?id=1045668#c16). **So it is recommended to use `/` to separate values, the next version may deprecate `:` separator.**
+
 ## Install
 
 ```shell
@@ -23,7 +25,7 @@ var output = postcss()
 
 ## Example
 
-A simple example using the custom ratio value `'16:9'`.
+A simple example using the custom ratio value `16 / 9`.
 
 
 ### Input
@@ -34,7 +36,11 @@ A simple example using the custom ratio value `'16:9'`.
 }
 
 .aspect-box {
-    aspect-ratio: '16:9';
+    aspect-ratio: 16 / 9;
+}
+
+.aspect-box2 {
+    aspect-ratio: 0.1 / 0.3;
 }
 ```
 
@@ -47,6 +53,10 @@ A simple example using the custom ratio value `'16:9'`.
 
 .aspect-box:before {
     padding-top: 56.25%;
+}
+
+.aspect-box2:before {
+    padding-top: 300%;
 }
 ```
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,5 @@
 var gulp = require('gulp')
 var postcss = require('gulp-postcss')
-var ifm = require('./index.js')
 var tape = require('gulp-tape')
 var tapDiff = require('tap-diff')
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-aspect-ratio-mini",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A PostCSS plugin to fix an element's dimensions to an aspect ratio.",
   "main": "index.js",
   "scripts": {
@@ -26,14 +26,14 @@
   },
   "homepage": "https://github.com/yisibl/postcss-aspect-ratio-mini",
   "dependencies": {
+    "number-precision": "^1.3.2",
     "postcss": "^7.0.6"
   },
   "devDependencies": {
     "gulp": "^3.9.0",
     "gulp-postcss": "^8.0.0",
-    "gulp-shell": "^0.5.2",
-    "gulp-tape": "0.0.7",
+    "gulp-tape": "1.0.0",
     "tap-diff": "^0.1.1",
-    "tape": "^4.4.0"
+    "tape": "^5.0.0"
   }
 }

--- a/test/fixtures/damo.actual.css
+++ b/test/fixtures/damo.actual.css
@@ -1,3 +1,11 @@
+.aspect-box {
+    position: relative;
+}
+
 [aspectratio][aspect-ratio="16:9"]:before {
-    padding-top: 56.25%
+    padding-top: 56.25%;
+}
+
+[aspectratio][aspect-ratio="16/9"]:before {
+    padding-top: 56.25%;
 }

--- a/test/fixtures/damo.css
+++ b/test/fixtures/damo.css
@@ -1,3 +1,11 @@
+.aspect-box {
+    position: relative;
+}
+
 [aspectratio][aspect-ratio="16:9"] {
     aspect-ratio: '16:9';
+}
+
+[aspectratio][aspect-ratio="16/9"] {
+    aspect-ratio: 16 / 9;
 }

--- a/test/fixtures/damo.expected.css
+++ b/test/fixtures/damo.expected.css
@@ -1,3 +1,11 @@
+.aspect-box {
+    position: relative;
+}
+
 [aspectratio][aspect-ratio="16:9"]:before {
-    padding-top: 56.25%
+    padding-top: 56.25%;
+}
+
+[aspectratio][aspect-ratio="16/9"]:before {
+    padding-top: 56.25%;
 }

--- a/test/fixtures/default.actual.css
+++ b/test/fixtures/default.actual.css
@@ -5,3 +5,11 @@
 .aspect-box:before {
     padding-top: 56.25%;
 }
+
+.aspect-box:before {
+    padding-top: 56.25%;
+}
+
+.aspect-box:before {
+    padding-top: 56.25%;
+}

--- a/test/fixtures/default.css
+++ b/test/fixtures/default.css
@@ -3,5 +3,13 @@
 }
 
 .aspect-box {
-    aspect-ratio: '16:9';
+    aspect-ratio: 16   /     9;
+}
+
+.aspect-box {
+    aspect-ratio: '16   :   9';
+}
+
+.aspect-box {
+    aspect-ratio: '16 |  9';
 }

--- a/test/fixtures/default.expected.css
+++ b/test/fixtures/default.expected.css
@@ -5,3 +5,11 @@
 .aspect-box:before {
     padding-top: 56.25%;
 }
+
+.aspect-box:before {
+    padding-top: 56.25%;
+}
+
+.aspect-box:before {
+    padding-top: 56.25%;
+}

--- a/test/fixtures/precision.actual.css
+++ b/test/fixtures/precision.actual.css
@@ -1,0 +1,11 @@
+.aspect-box {
+    position: relative;
+}
+
+.aspect-box:before {
+    padding-top: 300%;
+}
+
+.aspect-box:before {
+    padding-top: 110%;
+}

--- a/test/fixtures/precision.css
+++ b/test/fixtures/precision.css
@@ -1,0 +1,11 @@
+.aspect-box {
+    position: relative;
+}
+
+.aspect-box {
+    aspect-ratio: "0.1 / 0.3";
+}
+
+.aspect-box {
+    aspect-ratio: 1.1/1.21;
+}

--- a/test/fixtures/precision.expected.css
+++ b/test/fixtures/precision.expected.css
@@ -1,0 +1,11 @@
+.aspect-box {
+    position: relative;
+}
+
+.aspect-box:before {
+    padding-top: 300%;
+}
+
+.aspect-box:before {
+    padding-top: 110%;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -37,3 +37,8 @@ test('double-quote', function(t) {
   compareFixtures(t, 'double-quote', 'should equal')
   t.end()
 })
+
+test('number precision', function(t) {
+  compareFixtures(t, 'precision', 'should equal')
+  t.end()
+})


### PR DESCRIPTION
* Support `/` separator(`aspect-ratio: 16 / 9`)
* One or more whitespace characters are supported before or after the separator.
* Use number-precision module to fix JS calculation precision problem.